### PR TITLE
[WIP] Windows support for Radx

### DIFF
--- a/codebase/cmake/FindNetCDF.cmake
+++ b/codebase/cmake/FindNetCDF.cmake
@@ -1,0 +1,118 @@
+# - Find NetCDF
+# Find the native NetCDF includes and library
+#
+#  NETCDF_INCLUDE_DIR  - user modifiable choice of where netcdf headers are
+#  NETCDF_LIBRARY      - user modifiable choice of where netcdf libraries are
+#
+# Your package can require certain interfaces to be FOUND by setting these
+#
+#  NETCDF_CXX         - require the C++ interface and link the C++ library
+#  NETCDF_F77         - require the F77 interface and link the fortran library
+#  NETCDF_F90         - require the F90 interface and link the fortran library
+#
+# Or equivalently by calling FindNetCDF with a COMPONENTS argument containing one or
+# more of "CXX;F77;F90".
+#
+# When interfaces are requested the user has access to interface specific hints:
+#
+#  NETCDF_${LANG}_INCLUDE_DIR - where to search for interface header files
+#  NETCDF_${LANG}_LIBRARY     - where to search for interface libraries
+#
+# This module returns these variables for the rest of the project to use.
+#
+#  NETCDF_FOUND          - True if NetCDF found including required interfaces (see below)
+#  NETCDF_LIBRARIES      - All netcdf related libraries.
+#  NETCDF_INCLUDE_DIRS   - All directories to include.
+#  NETCDF_HAS_INTERFACES - Whether requested interfaces were found or not.
+#  NETCDF_${LANG}_INCLUDE_DIRS/NETCDF_${LANG}_LIBRARIES - C/C++/F70/F90 only interface
+#
+# Normal usage would be:
+#  set (NETCDF_F90 "YES")
+#  find_package (NetCDF REQUIRED)
+#  target_link_libraries (uses_everthing ${NETCDF_LIBRARIES})
+#  target_link_libraries (only_uses_f90 ${NETCDF_F90_LIBRARIES})
+
+#search starting from user editable cache var
+if (NETCDF_INCLUDE_DIR AND NETCDF_LIBRARY)
+  # Already in cache, be silent
+  set (NETCDF_FIND_QUIETLY TRUE)
+endif ()
+
+set(USE_DEFAULT_PATHS "NO_DEFAULT_PATH")
+if(NETCDF_USE_DEFAULT_PATHS)
+  set(USE_DEFAULT_PATHS "")
+endif()
+
+find_path (NETCDF_INCLUDE_DIR netcdf.h
+  HINTS "${NETCDF_DIR}/include")
+mark_as_advanced (NETCDF_INCLUDE_DIR)
+set (NETCDF_C_INCLUDE_DIRS ${NETCDF_INCLUDE_DIR})
+
+find_library (NETCDF_LIBRARY NAMES netcdf
+  HINTS "${NETCDF_DIR}/lib")
+mark_as_advanced (NETCDF_LIBRARY)
+
+set (NETCDF_C_LIBRARIES ${NETCDF_LIBRARY})
+
+#start finding requested language components
+set (NetCDF_libs "")
+set (NetCDF_includes "${NETCDF_INCLUDE_DIR}")
+
+get_filename_component (NetCDF_lib_dirs "${NETCDF_LIBRARY}" PATH)
+set (NETCDF_HAS_INTERFACES "YES") # will be set to NO if we're missing any interfaces
+
+macro (NetCDF_check_interface lang header libs)
+  if (NETCDF_${lang})
+    #search starting from user modifiable cache var
+    find_path (NETCDF_${lang}_INCLUDE_DIR NAMES ${header}
+      HINTS "${NETCDF_INCLUDE_DIR}"
+      HINTS "${NETCDF_${lang}_ROOT}/include"
+      ${USE_DEFAULT_PATHS})
+
+    find_library (NETCDF_${lang}_LIBRARY NAMES ${libs}
+      HINTS "${NetCDF_lib_dirs}"
+      HINTS "${NETCDF_${lang}_ROOT}/lib"
+      ${USE_DEFAULT_PATHS})
+
+    mark_as_advanced (NETCDF_${lang}_INCLUDE_DIR NETCDF_${lang}_LIBRARY)
+
+    #export to internal varS that rest of project can use directly
+    set (NETCDF_${lang}_LIBRARIES ${NETCDF_${lang}_LIBRARY})
+    set (NETCDF_${lang}_INCLUDE_DIRS ${NETCDF_${lang}_INCLUDE_DIR})
+
+    if (NETCDF_${lang}_INCLUDE_DIR AND NETCDF_${lang}_LIBRARY)
+      list (APPEND NetCDF_libs ${NETCDF_${lang}_LIBRARY})
+      list (APPEND NetCDF_includes ${NETCDF_${lang}_INCLUDE_DIR})
+    else ()
+      set (NETCDF_HAS_INTERFACES "NO")
+      message (STATUS "Failed to find NetCDF interface for ${lang}")
+    endif ()
+  endif ()
+endmacro ()
+
+list (FIND NetCDF_FIND_COMPONENTS "CXX" _nextcomp)
+if (_nextcomp GREATER -1)
+  set (NETCDF_CXX 1)
+endif ()
+list (FIND NetCDF_FIND_COMPONENTS "F77" _nextcomp)
+if (_nextcomp GREATER -1)
+  set (NETCDF_F77 1)
+endif ()
+list (FIND NetCDF_FIND_COMPONENTS "F90" _nextcomp)
+if (_nextcomp GREATER -1)
+  set (NETCDF_F90 1)
+endif ()
+NetCDF_check_interface (CXX netcdfcpp.h netcdf_c++)
+NetCDF_check_interface (F77 netcdf.inc  netcdff)
+NetCDF_check_interface (F90 netcdf.mod  netcdff)
+
+#export accumulated results to internal varS that rest of project can depend on
+list (APPEND NetCDF_libs "${NETCDF_C_LIBRARIES}")
+set (NETCDF_LIBRARIES ${NetCDF_libs})
+set (NETCDF_INCLUDE_DIRS ${NetCDF_includes})
+
+# handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
+# all listed variables are TRUE
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (NetCDF
+  DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDE_DIRS NETCDF_HAS_INTERFACES)

--- a/codebase/cmake/FindThreads.cmake
+++ b/codebase/cmake/FindThreads.cmake
@@ -1,0 +1,246 @@
+# Updated FindThreads.cmake that supports pthread-win32
+# Downloaded from http://www.vtk.org/Bug/bug_view_advanced_page.php?bug_id=6399
+
+# - This module determines the thread library of the system.
+#
+# The following variables are set
+#  CMAKE_THREAD_LIBS_INIT     - the thread library
+#  CMAKE_USE_SPROC_INIT       - are we using sproc?
+#  CMAKE_USE_WIN32_THREADS_INIT - using WIN32 threads?
+#  CMAKE_USE_PTHREADS_INIT    - are we using pthreads
+#  CMAKE_HP_PTHREADS_INIT     - are we using hp pthreads
+#
+# If use of pthreads-win32 is desired, the following variables
+# can be set.
+#
+#  THREADS_USE_PTHREADS_WIN32 -
+#    Setting this to true searches for the pthreads-win32
+#    port (since CMake 2.8.0)
+#
+#  THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME
+#      C  = no exceptions (default)
+#         (NOTE: This is the default scheme on most POSIX thread
+#          implementations and what you should probably be using)
+#      CE = C++ Exception Handling
+#      SE = Structure Exception Handling (MSVC only)
+#      (NOTE: Changing this option from the default may affect
+#       the portability of your application.  See pthreads-win32
+#       documentation for more details.)
+#
+#======================================================
+# Example usage where threading library
+# is provided by the system:
+#
+#   find_package(Threads REQUIRED)
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+# Example usage if pthreads-win32 is desired on Windows
+# or a system provided thread library:
+#
+#   set(THREADS_USE_PTHREADS_WIN32 true)
+#   find_package(Threads REQUIRED)
+#   include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+#
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+
+INCLUDE (CheckIncludeFiles)
+INCLUDE (CheckLibraryExists)
+SET(Threads_FOUND FALSE)
+
+IF(WIN32 AND NOT CYGWIN AND THREADS_USE_PTHREADS_WIN32)
+  SET(_Threads_ptwin32 true)
+ENDIF()
+
+# Do we have sproc?
+IF(CMAKE_SYSTEM MATCHES IRIX)
+  CHECK_INCLUDE_FILES("sys/types.h;sys/prctl.h"  CMAKE_HAVE_SPROC_H)
+ENDIF()
+
+IF(CMAKE_HAVE_SPROC_H)
+  # We have sproc
+  SET(CMAKE_USE_SPROC_INIT 1)
+
+ELSEIF(_Threads_ptwin32)
+
+  IF(NOT DEFINED THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME)
+    # Assign the default scheme
+    SET(THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME "C")
+  ELSE()
+    # Validate the scheme specified by the user
+    IF(NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "C" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "CE" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+         MESSAGE(FATAL_ERROR "See documentation for FindPthreads.cmake, only C, CE, and SE modes are allowed")
+    ENDIF()
+    IF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+      MESSAGE(FATAL_ERROR "Structured Exception Handling is only allowed for MSVC")
+    ENDIF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+  ENDIF()
+
+  FIND_PATH(THREADS_PTHREADS_INCLUDE_DIR pthread.h)
+  
+  # Determine the library filename
+  IF(MSVC)
+    SET(_Threads_pthreads_libname
+        pthreadV${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSEIF(MINGW)
+    SET(_Threads_pthreads_libname
+        pthreadG${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSE()
+    MESSAGE(FATAL_ERROR "This should never happen")
+  ENDIF()
+
+  # Use the include path to help find the library if possible
+  SET(_Threads_lib_paths "")
+  IF(THREADS_PTHREADS_INCLUDE_DIR)
+     GET_FILENAME_COMPONENT(_Threads_root_dir
+                            ${THREADS_PTHREADS_INCLUDE_DIR} PATH)
+     SET(_Threads_lib_paths ${_Threads_root_dir}/lib)
+  ENDIF()
+  FIND_LIBRARY(THREADS_PTHREADS_WIN32_LIBRARY
+               NAMES ${_Threads_pthreads_libname}
+               PATHS ${_Threads_lib_paths}
+               DOC "The Portable Threads Library for Win32"
+               NO_SYSTEM_PATH
+               )
+
+  IF(THREADS_PTHREADS_INCLUDE_DIR AND THREADS_PTHREADS_WIN32_LIBRARY)
+    MARK_AS_ADVANCED(THREADS_PTHREADS_INCLUDE_DIR)
+    SET(CMAKE_THREAD_LIBS_INIT ${THREADS_PTHREADS_WIN32_LIBRARY})
+    SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+    SET(Threads_FOUND TRUE)
+  ENDIF()
+
+  MARK_AS_ADVANCED(THREADS_PTHREADS_WIN32_LIBRARY)
+
+ELSE()
+  # Do we have pthreads?
+  CHECK_INCLUDE_FILES("pthread.h" CMAKE_HAVE_PTHREAD_H)
+  IF(CMAKE_HAVE_PTHREAD_H)
+
+    #
+    # We have pthread.h
+    # Let's check for the library now.
+    #
+    SET(CMAKE_HAVE_THREADS_LIBRARY)
+    IF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+      # Do we have -lpthreads
+      CHECK_LIBRARY_EXISTS(pthreads pthread_create "" CMAKE_HAVE_PTHREADS_CREATE)
+      IF(CMAKE_HAVE_PTHREADS_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthreads")
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+        SET(Threads_FOUND TRUE)
+      ENDIF()
+
+      # Ok, how about -lpthread
+      CHECK_LIBRARY_EXISTS(pthread pthread_create "" CMAKE_HAVE_PTHREAD_CREATE)
+      IF(CMAKE_HAVE_PTHREAD_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthread")
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+      ENDIF()
+
+      IF(CMAKE_SYSTEM MATCHES "SunOS.*")
+        # On sun also check for -lthread
+        CHECK_LIBRARY_EXISTS(thread thr_create "" CMAKE_HAVE_THR_CREATE)
+        IF(CMAKE_HAVE_THR_CREATE)
+          SET(CMAKE_THREAD_LIBS_INIT "-lthread")
+          SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+          SET(Threads_FOUND TRUE)
+        ENDIF()
+      ENDIF(CMAKE_SYSTEM MATCHES "SunOS.*")
+
+    ENDIF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+    IF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+      # If we did not found -lpthread, -lpthread, or -lthread, look for -pthread
+      IF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+        MESSAGE(STATUS "Check if compiler accepts -pthread")
+        TRY_RUN(THREADS_PTHREAD_ARG THREADS_HAVE_PTHREAD_ARG
+          ${CMAKE_BINARY_DIR}
+          ${CMAKE_ROOT}/Modules/CheckForPthreads.c
+          CMAKE_FLAGS -DLINK_LIBRARIES:STRING=-pthread
+          COMPILE_OUTPUT_VARIABLE OUTPUT)
+
+        IF(THREADS_HAVE_PTHREAD_ARG)
+          IF(THREADS_PTHREAD_ARG MATCHES "^2$")
+            SET(Threads_FOUND TRUE)
+            MESSAGE(STATUS "Check if compiler accepts -pthread - yes")
+          ELSE()
+            MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+            FILE(APPEND 
+              ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log 
+              "Determining if compiler accepts -pthread returned ${THREADS_PTHREAD_ARG} instead of 2. The compiler had the following output:\n${OUTPUT}\n\n")
+          ENDIF()
+        ELSE()
+          MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+          FILE(APPEND 
+            ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log 
+            "Determining if compiler accepts -pthread failed with the following output:\n${OUTPUT}\n\n")
+        ENDIF()
+
+      ENDIF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+
+      IF(THREADS_HAVE_PTHREAD_ARG)
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_THREAD_LIBS_INIT "-pthread")
+      ENDIF()
+
+    ENDIF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+  ENDIF(CMAKE_HAVE_PTHREAD_H)
+ENDIF()
+
+IF(CMAKE_THREAD_LIBS_INIT)
+  SET(CMAKE_USE_PTHREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_SYSTEM MATCHES "Windows"
+   AND NOT THREADS_USE_PTHREADS_WIN32)
+  SET(CMAKE_USE_WIN32_THREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_USE_PTHREADS_INIT)
+  IF(CMAKE_SYSTEM MATCHES "HP-UX-*")
+    # Use libcma if it exists and can be used.  It provides more
+    # symbols than the plain pthread library.  CMA threads
+    # have actually been deprecated:
+    #   http://docs.hp.com/en/B3920-90091/ch12s03.html#d0e11395
+    #   http://docs.hp.com/en/947/d8.html
+    # but we need to maintain compatibility here.
+    # The CMAKE_HP_PTHREADS setting actually indicates whether CMA threads
+    # are available.
+    CHECK_LIBRARY_EXISTS(cma pthread_attr_create "" CMAKE_HAVE_HP_CMA)
+    IF(CMAKE_HAVE_HP_CMA)
+      SET(CMAKE_THREAD_LIBS_INIT "-lcma")
+      SET(CMAKE_HP_PTHREADS_INIT 1)
+      SET(Threads_FOUND TRUE)
+    ENDIF(CMAKE_HAVE_HP_CMA)
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "OSF1-V*")
+    SET(CMAKE_USE_PTHREADS_INIT 0)
+    SET(CMAKE_THREAD_LIBS_INIT )
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "CYGWIN_NT*")
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+    SET(Threads_FOUND TRUE)
+    SET(CMAKE_THREAD_LIBS_INIT )
+    SET(CMAKE_USE_WIN32_THREADS_INIT 0)
+  ENDIF()
+ENDIF(CMAKE_USE_PTHREADS_INIT)
+
+INCLUDE(FindPackageHandleStandardArgs)
+IF(_Threads_ptwin32)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG
+    THREADS_PTHREADS_WIN32_LIBRARY THREADS_PTHREADS_INCLUDE_DIR)
+ELSE()
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG Threads_FOUND)
+ENDIF()

--- a/codebase/cmake/FindUDUnits.cmake
+++ b/codebase/cmake/FindUDUnits.cmake
@@ -1,0 +1,54 @@
+# - Find UDUnits
+# Find the UDUnits includes and library
+#
+#  UDUNITS_INCLUDE_DIR  - user modifiable choice of where netcdf headers are
+#  UDUNITS_LIBRARY      - user modifiable choice of where netcdf libraries are
+
+#search starting from user editable cache var
+if (UDUNITS_INCLUDE_DIR AND UDUNITS_LIBRARY)
+  # Already in cache, be silent
+  set (UDUNITS_FIND_QUIETLY TRUE)
+endif ()
+
+# find the library
+# first look where the user told us
+if (UDUNITS_DIR)
+  find_library (UDUNITS_LIBRARY NAMES udunits2
+    PATHS "${UDUNITS_DIR}/lib" "${UDUNITS_DIR}/lib64"
+    NO_DEFAULT_PATH)
+endif()
+
+# next look in LD_LIBRARY_PATH for libraries
+find_library (UDUNITS_LIBRARY NAMES udunits2
+  PATHS ENV LD_LIBRARY_PATH NO_DEFAULT_PATH)
+
+# finally CMake can look
+find_library (UDUNITS_LIBRARY NAMES udunits2)
+
+mark_as_advanced (UDUNITS_LIBRARY)
+
+# find the header
+# first look where the user told us
+if (UDUNITS_DIR)
+  find_path (UDUNITS_INCLUDE_DIR udunits2.h
+    PATHS "${UDUNITS_DIR}/include" NO_DEFAULT_PATH)
+endif()
+
+# then look relative to library dir
+get_filename_component(UDUNITS_LIBRARY_DIR
+  ${UDUNITS_LIBRARY} DIRECTORY)
+
+find_path (UDUNITS_INCLUDE_DIR udunits2.h
+  PATHS "${UDUNITS_LIBRARY_DIR}/../include"
+  NO_DEFAULT_PATH)
+
+# finally CMake can look
+find_path (UDUNITS_INCLUDE_DIR udunits2.h)
+
+mark_as_advanced (UDUNITS_INCLUDE_DIR)
+
+# handle the QUIETLY and REQUIRED arguments and set UDUNITS_FOUND to TRUE if
+# all listed variables are TRUE
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (UDUnits
+  DEFAULT_MSG UDUNITS_LIBRARY UDUNITS_INCLUDE_DIR)

--- a/codebase/compat/win32/dirent.h
+++ b/codebase/compat/win32/dirent.h
@@ -1,0 +1,917 @@
+/*
+ * Dirent interface for Microsoft Visual Studio
+ * Version 1.21
+ *
+ * Copyright (C) 2006-2012 Toni Ronkko
+ * This file is part of dirent.  Dirent may be freely distributed
+ * under the MIT license.  For all details and documentation, see
+ * https://github.com/tronkko/dirent
+ */
+#ifndef DIRENT_H
+#define DIRENT_H
+
+/*
+ * Define architecture flags so we don't need to include windows.h.
+ * Avoiding windows.h makes it simpler to use windows sockets in conjunction
+ * with dirent.h.
+ */
+#if !defined(_68K_) && !defined(_MPPC_) && !defined(_X86_) && !defined(_IA64_) && !defined(_AMD64_) && defined(_M_IX86)
+#   define _X86_
+#endif
+#if !defined(_68K_) && !defined(_MPPC_) && !defined(_X86_) && !defined(_IA64_) && !defined(_AMD64_) && defined(_M_AMD64)
+#define _AMD64_
+#endif
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <windef.h>
+#include <winbase.h>
+#include <wchar.h>
+#include <string.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+
+/* Indicates that d_type field is available in dirent structure */
+#define _DIRENT_HAVE_D_TYPE
+
+/* Indicates that d_namlen field is available in dirent structure */
+#define _DIRENT_HAVE_D_NAMLEN
+
+/* Entries missing from MSVC 6.0 */
+#if !defined(FILE_ATTRIBUTE_DEVICE)
+#   define FILE_ATTRIBUTE_DEVICE 0x40
+#endif
+
+/* File type and permission flags for stat(), general mask */
+#if !defined(S_IFMT)
+#   define S_IFMT _S_IFMT
+#endif
+
+/* Directory bit */
+#if !defined(S_IFDIR)
+#   define S_IFDIR _S_IFDIR
+#endif
+
+/* Character device bit */
+#if !defined(S_IFCHR)
+#   define S_IFCHR _S_IFCHR
+#endif
+
+/* Pipe bit */
+#if !defined(S_IFFIFO)
+#   define S_IFFIFO _S_IFFIFO
+#endif
+
+/* Regular file bit */
+#if !defined(S_IFREG)
+#   define S_IFREG _S_IFREG
+#endif
+
+/* Read permission */
+#if !defined(S_IREAD)
+#   define S_IREAD _S_IREAD
+#endif
+
+/* Write permission */
+#if !defined(S_IWRITE)
+#   define S_IWRITE _S_IWRITE
+#endif
+
+/* Execute permission */
+#if !defined(S_IEXEC)
+#   define S_IEXEC _S_IEXEC
+#endif
+
+/* Pipe */
+#if !defined(S_IFIFO)
+#   define S_IFIFO _S_IFIFO
+#endif
+
+/* Block device */
+#if !defined(S_IFBLK)
+#   define S_IFBLK 0
+#endif
+
+/* Link */
+#if !defined(S_IFLNK)
+#   define S_IFLNK 0
+#endif
+
+/* Socket */
+#if !defined(S_IFSOCK)
+#   define S_IFSOCK 0
+#endif
+
+/* Read user permission */
+#if !defined(S_IRUSR)
+#   define S_IRUSR S_IREAD
+#endif
+
+/* Write user permission */
+#if !defined(S_IWUSR)
+#   define S_IWUSR S_IWRITE
+#endif
+
+/* Execute user permission */
+#if !defined(S_IXUSR)
+#   define S_IXUSR 0
+#endif
+
+/* Read group permission */
+#if !defined(S_IRGRP)
+#   define S_IRGRP 0
+#endif
+
+/* Write group permission */
+#if !defined(S_IWGRP)
+#   define S_IWGRP 0
+#endif
+
+/* Execute group permission */
+#if !defined(S_IXGRP)
+#   define S_IXGRP 0
+#endif
+
+/* Read others permission */
+#if !defined(S_IROTH)
+#   define S_IROTH 0
+#endif
+
+/* Write others permission */
+#if !defined(S_IWOTH)
+#   define S_IWOTH 0
+#endif
+
+/* Execute others permission */
+#if !defined(S_IXOTH)
+#   define S_IXOTH 0
+#endif
+
+/* Maximum length of file name */
+#if !defined(PATH_MAX)
+#   define PATH_MAX MAX_PATH
+#endif
+#if !defined(FILENAME_MAX)
+#   define FILENAME_MAX MAX_PATH
+#endif
+#if !defined(NAME_MAX)
+#   define NAME_MAX FILENAME_MAX
+#endif
+
+/* File type flags for d_type */
+#define DT_UNKNOWN 0
+#define DT_REG S_IFREG
+#define DT_DIR S_IFDIR
+#define DT_FIFO S_IFIFO
+#define DT_SOCK S_IFSOCK
+#define DT_CHR S_IFCHR
+#define DT_BLK S_IFBLK
+#define DT_LNK S_IFLNK
+
+/* Macros for converting between st_mode and d_type */
+#define IFTODT(mode) ((mode) & S_IFMT)
+#define DTTOIF(type) (type)
+
+/*
+ * File type macros.  Note that block devices, sockets and links cannot be
+ * distinguished on Windows and the macros S_ISBLK, S_ISSOCK and S_ISLNK are
+ * only defined for compatibility.  These macros should always return false
+ * on Windows.
+ */
+#if !defined(S_ISFIFO)
+#   define S_ISFIFO(mode) (((mode) & S_IFMT) == S_IFIFO)
+#endif
+#if !defined(S_ISDIR)
+#   define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+#endif
+#if !defined(S_ISREG)
+#   define S_ISREG(mode) (((mode) & S_IFMT) == S_IFREG)
+#endif
+#if !defined(S_ISLNK)
+#   define S_ISLNK(mode) (((mode) & S_IFMT) == S_IFLNK)
+#endif
+#if !defined(S_ISSOCK)
+#   define S_ISSOCK(mode) (((mode) & S_IFMT) == S_IFSOCK)
+#endif
+#if !defined(S_ISCHR)
+#   define S_ISCHR(mode) (((mode) & S_IFMT) == S_IFCHR)
+#endif
+#if !defined(S_ISBLK)
+#   define S_ISBLK(mode) (((mode) & S_IFMT) == S_IFBLK)
+#endif
+
+/* Return the exact length of d_namlen without zero terminator */
+#define _D_EXACT_NAMLEN(p) ((p)->d_namlen)
+
+/* Return number of bytes needed to store d_namlen */
+#define _D_ALLOC_NAMLEN(p) (PATH_MAX)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Wide-character version */
+struct _wdirent {
+    /* Always zero */
+    long d_ino;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    wchar_t d_name[PATH_MAX];
+};
+typedef struct _wdirent _wdirent;
+
+struct _WDIR {
+    /* Current directory entry */
+    struct _wdirent ent;
+
+    /* Private file data */
+    WIN32_FIND_DATAW data;
+
+    /* True if data is valid */
+    int cached;
+
+    /* Win32 search handle */
+    HANDLE handle;
+
+    /* Initial directory name */
+    wchar_t *patt;
+};
+typedef struct _WDIR _WDIR;
+
+static _WDIR *_wopendir (const wchar_t *dirname);
+static struct _wdirent *_wreaddir (_WDIR *dirp);
+static int _wclosedir (_WDIR *dirp);
+static void _wrewinddir (_WDIR* dirp);
+
+
+/* For compatibility with Symbian */
+#define wdirent _wdirent
+#define WDIR _WDIR
+#define wopendir _wopendir
+#define wreaddir _wreaddir
+#define wclosedir _wclosedir
+#define wrewinddir _wrewinddir
+
+
+/* Multi-byte character versions */
+struct dirent {
+    /* Always zero */
+    long d_ino;
+
+    /* Structure size */
+    unsigned short d_reclen;
+
+    /* Length of name without \0 */
+    size_t d_namlen;
+
+    /* File type */
+    int d_type;
+
+    /* File name */
+    char d_name[PATH_MAX];
+};
+typedef struct dirent dirent;
+
+struct DIR {
+    struct dirent ent;
+    struct _WDIR *wdirp;
+};
+typedef struct DIR DIR;
+
+static DIR *opendir (const char *dirname);
+static struct dirent *readdir (DIR *dirp);
+static int closedir (DIR *dirp);
+static void rewinddir (DIR* dirp);
+
+
+/* Internal utility functions */
+static WIN32_FIND_DATAW *dirent_first (_WDIR *dirp);
+static WIN32_FIND_DATAW *dirent_next (_WDIR *dirp);
+
+static int dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count);
+
+static int dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes,
+    const wchar_t *wcstr,
+    size_t count);
+
+static void dirent_set_errno (int error);
+
+/*
+ * Open directory stream DIRNAME for read and return a pointer to the
+ * internal working area that is used to retrieve individual directory
+ * entries.
+ */
+static _WDIR*
+_wopendir(
+    const wchar_t *dirname)
+{
+    _WDIR *dirp = NULL;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate new _WDIR structure */
+    dirp = (_WDIR*) malloc (sizeof (struct _WDIR));
+    if (dirp != NULL) {
+        DWORD n;
+
+        /* Reset _WDIR structure */
+        dirp->handle = INVALID_HANDLE_VALUE;
+        dirp->patt = NULL;
+        dirp->cached = 0;
+
+        /* Compute the length of full path plus zero terminator */
+        n = GetFullPathNameW (dirname, 0, NULL, NULL);
+
+        /* Allocate room for absolute directory name and search pattern */
+        dirp->patt = (wchar_t*) malloc (sizeof (wchar_t) * n + 16);
+        if (dirp->patt) {
+
+            /*
+             * Convert relative directory name to an absolute one.  This
+             * allows rewinddir() to function correctly even when current
+             * working directory is changed between opendir() and rewinddir().
+             */
+            n = GetFullPathNameW (dirname, n, dirp->patt, NULL);
+            if (n > 0) {
+                wchar_t *p;
+
+                /* Append search pattern \* to the directory name */
+                p = dirp->patt + n;
+                if (dirp->patt < p) {
+                    switch (p[-1]) {
+                    case '\\':
+                    case '/':
+                    case ':':
+                        /* Directory ends in path separator, e.g. c:\temp\ */
+                        /*NOP*/;
+                        break;
+
+                    default:
+                        /* Directory name doesn't end in path separator */
+                        *p++ = '\\';
+                    }
+                }
+                *p++ = '*';
+                *p = '\0';
+
+                /* Open directory stream and retrieve the first entry */
+                if (dirent_first (dirp)) {
+                    /* Directory stream opened successfully */
+                    error = 0;
+                } else {
+                    /* Cannot retrieve first entry */
+                    error = 1;
+                    dirent_set_errno (ENOENT);
+                }
+
+            } else {
+                /* Cannot retrieve full path name */
+                dirent_set_errno (ENOENT);
+                error = 1;
+            }
+
+        } else {
+            /* Cannot allocate memory for search pattern */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate _WDIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        _wclosedir (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.  The directory entry is returned in dirent
+ * structure in the d_name field.  Individual directory entries returned by
+ * this function include regular files, sub-directories, pseudo-directories
+ * "." and ".." as well as volume labels, hidden files and system files.
+ */
+static struct _wdirent*
+_wreaddir(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+    struct _wdirent *entp;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp);
+    if (datap) {
+        size_t n;
+        DWORD attr;
+        
+        /* Pointer to directory entry to return */
+        entp = &dirp->ent;
+
+        /* 
+         * Copy file name as wide-character string.  If the file name is too
+         * long to fit in to the destination buffer, then truncate file name
+         * to PATH_MAX characters and zero-terminate the buffer.
+         */
+        n = 0;
+        while (n + 1 < PATH_MAX  &&  datap->cFileName[n] != 0) {
+            entp->d_name[n] = datap->cFileName[n];
+            n++;
+        }
+        dirp->ent.d_name[n] = 0;
+
+        /* Length of file name excluding zero terminator */
+        entp->d_namlen = n;
+
+        /* File type */
+        attr = datap->dwFileAttributes;
+        if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+            entp->d_type = DT_CHR;
+        } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+            entp->d_type = DT_DIR;
+        } else {
+            entp->d_type = DT_REG;
+        }
+
+        /* Reset dummy fields */
+        entp->d_ino = 0;
+        entp->d_reclen = sizeof (struct _wdirent);
+
+    } else {
+
+        /* Last directory entry read */
+        entp = NULL;
+
+    }
+
+    return entp;
+}
+
+/*
+ * Close directory stream opened by opendir() function.  This invalidates the
+ * DIR structure as well as any directory entry read previously by
+ * _wreaddir().
+ */
+static int
+_wclosedir(
+    _WDIR *dirp)
+{
+    int ok;
+    if (dirp) {
+
+        /* Release search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+        }
+
+        /* Release search pattern */
+        if (dirp->patt) {
+            free (dirp->patt);
+            dirp->patt = NULL;
+        }
+
+        /* Release directory structure */
+        free (dirp);
+        ok = /*success*/0;
+
+    } else {
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream such that _wreaddir() returns the very first
+ * file name again.
+ */
+static void
+_wrewinddir(
+    _WDIR* dirp)
+{
+    if (dirp) {
+        /* Release existing search handle */
+        if (dirp->handle != INVALID_HANDLE_VALUE) {
+            FindClose (dirp->handle);
+        }
+
+        /* Open new search handle */
+        dirent_first (dirp);
+    }
+}
+
+/* Get first directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_first(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *datap;
+
+    /* Open directory and retrieve the first entry */
+    dirp->handle = FindFirstFileW (dirp->patt, &dirp->data);
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* a directory entry is now waiting in memory */
+        datap = &dirp->data;
+        dirp->cached = 1;
+
+    } else {
+
+        /* Failed to re-open directory: no directory entry in memory */
+        dirp->cached = 0;
+        datap = NULL;
+
+    }
+    return datap;
+}
+
+/* Get next directory entry (internal) */
+static WIN32_FIND_DATAW*
+dirent_next(
+    _WDIR *dirp)
+{
+    WIN32_FIND_DATAW *p;
+
+    /* Get next directory entry */
+    if (dirp->cached != 0) {
+
+        /* A valid directory entry already in memory */
+        p = &dirp->data;
+        dirp->cached = 0;
+
+    } else if (dirp->handle != INVALID_HANDLE_VALUE) {
+
+        /* Get the next directory entry from stream */
+        if (FindNextFileW (dirp->handle, &dirp->data) != FALSE) {
+            /* Got a file */
+            p = &dirp->data;
+        } else {
+            /* The very last entry has been processed or an error occured */
+            FindClose (dirp->handle);
+            dirp->handle = INVALID_HANDLE_VALUE;
+            p = NULL;
+        }
+
+    } else {
+
+        /* End of directory stream reached */
+        p = NULL;
+
+    }
+
+    return p;
+}
+
+/* 
+ * Open directory stream using plain old C-string.
+ */
+static DIR*
+opendir(
+    const char *dirname) 
+{
+    struct DIR *dirp;
+    int error;
+
+    /* Must have directory name */
+    if (dirname == NULL  ||  dirname[0] == '\0') {
+        dirent_set_errno (ENOENT);
+        return NULL;
+    }
+
+    /* Allocate memory for DIR structure */
+    dirp = (DIR*) malloc (sizeof (struct DIR));
+    if (dirp) {
+        wchar_t wname[PATH_MAX];
+        size_t n;
+
+        /* Convert directory name to wide-character string */
+        error = dirent_mbstowcs_s (&n, wname, PATH_MAX, dirname, PATH_MAX);
+        if (!error) {
+
+            /* Open directory stream using wide-character name */
+            dirp->wdirp = _wopendir (wname);
+            if (dirp->wdirp) {
+                /* Directory stream opened */
+                error = 0;
+            } else {
+                /* Failed to open directory stream */
+                error = 1;
+            }
+
+        } else {
+            /* 
+             * Cannot convert file name to wide-character string.  This
+             * occurs if the string contains invalid multi-byte sequences or
+             * the output buffer is too small to contain the resulting
+             * string.
+             */
+            error = 1;
+        }
+
+    } else {
+        /* Cannot allocate DIR structure */
+        error = 1;
+    }
+
+    /* Clean up in case of error */
+    if (error  &&  dirp) {
+        free (dirp);
+        dirp = NULL;
+    }
+
+    return dirp;
+}
+
+/*
+ * Read next directory entry.
+ *
+ * When working with text consoles, please note that file names returned by
+ * readdir() are represented in the default ANSI code page while any output to
+ * console is typically formatted on another code page.  Thus, non-ASCII
+ * characters in file names will not usually display correctly on console.  The
+ * problem can be fixed in two ways: (1) change the character set of console
+ * to 1252 using chcp utility and use Lucida Console font, or (2) use
+ * _cprintf function when writing to console.  The _cprinf() will re-encode
+ * ANSI strings to the console code page so many non-ASCII characters will
+ * display correcly.
+ */
+static struct dirent*
+readdir(
+    DIR *dirp) 
+{
+    WIN32_FIND_DATAW *datap;
+    struct dirent *entp;
+
+    /* Read next directory entry */
+    datap = dirent_next (dirp->wdirp);
+    if (datap) {
+        size_t n;
+        int error;
+
+        /* Attempt to convert file name to multi-byte string */
+        error = dirent_wcstombs_s(
+            &n, dirp->ent.d_name, PATH_MAX, datap->cFileName, PATH_MAX);
+
+        /* 
+         * If the file name cannot be represented by a multi-byte string,
+         * then attempt to use old 8+3 file name.  This allows traditional
+         * Unix-code to access some file names despite of unicode
+         * characters, although file names may seem unfamiliar to the user.
+         *
+         * Be ware that the code below cannot come up with a short file
+         * name unless the file system provides one.  At least
+         * VirtualBox shared folders fail to do this.
+         */
+        if (error  &&  datap->cAlternateFileName[0] != '\0') {
+            error = dirent_wcstombs_s(
+                &n, dirp->ent.d_name, PATH_MAX, 
+                datap->cAlternateFileName, PATH_MAX);
+        }
+
+        if (!error) {
+            DWORD attr;
+
+            /* Initialize directory entry for return */
+            entp = &dirp->ent;
+
+            /* Length of file name excluding zero terminator */
+            entp->d_namlen = n - 1;
+
+            /* File attributes */
+            attr = datap->dwFileAttributes;
+            if ((attr & FILE_ATTRIBUTE_DEVICE) != 0) {
+                entp->d_type = DT_CHR;
+            } else if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+                entp->d_type = DT_DIR;
+            } else {
+                entp->d_type = DT_REG;
+            }
+
+            /* Reset dummy fields */
+            entp->d_ino = 0;
+            entp->d_reclen = sizeof (struct dirent);
+
+        } else {
+            /* 
+             * Cannot convert file name to multi-byte string so construct
+             * an errornous directory entry and return that.  Note that
+             * we cannot return NULL as that would stop the processing
+             * of directory entries completely.
+             */
+            entp = &dirp->ent;
+            entp->d_name[0] = '?';
+            entp->d_name[1] = '\0';
+            entp->d_namlen = 1;
+            entp->d_type = DT_UNKNOWN;
+            entp->d_ino = 0;
+            entp->d_reclen = 0;
+        }
+
+    } else {
+        /* No more directory entries */
+        entp = NULL;
+    }
+
+    return entp;
+}
+
+/*
+ * Close directory stream.
+ */
+static int
+closedir(
+    DIR *dirp) 
+{
+    int ok;
+    if (dirp) {
+
+        /* Close wide-character directory stream */
+        ok = _wclosedir (dirp->wdirp);
+        dirp->wdirp = NULL;
+
+        /* Release multi-byte character version */
+        free (dirp);
+
+    } else {
+
+        /* Invalid directory stream */
+        dirent_set_errno (EBADF);
+        ok = /*failure*/-1;
+
+    }
+    return ok;
+}
+
+/*
+ * Rewind directory stream to beginning.
+ */
+static void
+rewinddir(
+    DIR* dirp) 
+{
+    /* Rewind wide-character string directory stream */
+    _wrewinddir (dirp->wdirp);
+}
+
+/* Convert multi-byte string to wide character string */
+static int
+dirent_mbstowcs_s(
+    size_t *pReturnValue,
+    wchar_t *wcstr,
+    size_t sizeInWords,
+    const char *mbstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = mbstowcs_s (pReturnValue, wcstr, sizeInWords, mbstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to wide-character string (or count characters) */
+    n = mbstowcs (wcstr, mbstr, sizeInWords);
+    if (!wcstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (wcstr  &&  sizeInWords) {
+            if (n >= sizeInWords) {
+                n = sizeInWords - 1;
+            }
+            wcstr[n] = 0;
+        }
+
+        /* Length of resuting multi-byte string WITH zero terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Could not convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Convert wide-character string to multi-byte string */
+static int
+dirent_wcstombs_s(
+    size_t *pReturnValue,
+    char *mbstr,
+    size_t sizeInBytes, /* max size of mbstr */
+    const wchar_t *wcstr,
+    size_t count)
+{
+    int error;
+
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 or later */
+    error = wcstombs_s (pReturnValue, mbstr, sizeInBytes, wcstr, count);
+
+#else
+
+    /* Older Visual Studio or non-Microsoft compiler */
+    size_t n;
+
+    /* Convert to multi-byte string (or count the number of bytes needed) */
+    n = wcstombs (mbstr, wcstr, sizeInBytes);
+    if (!mbstr  ||  n < count) {
+
+        /* Zero-terminate output buffer */
+        if (mbstr  &&  sizeInBytes) {
+            if (n >= sizeInBytes) {
+                n = sizeInBytes - 1;
+            }
+            mbstr[n] = '\0';
+        }
+
+        /* Lenght of resulting multi-bytes string WITH zero-terminator */
+        if (pReturnValue) {
+            *pReturnValue = n + 1;
+        }
+
+        /* Success */
+        error = 0;
+
+    } else {
+
+        /* Cannot convert string */
+        error = 1;
+
+    }
+
+#endif
+
+    return error;
+}
+
+/* Set errno variable */
+static void
+dirent_set_errno(
+    int error)
+{
+#if defined(_MSC_VER)  &&  _MSC_VER >= 1400
+
+    /* Microsoft Visual Studio 2005 and later */
+    _set_errno (error);
+
+#else
+
+    /* Non-Microsoft compiler or older Microsoft compiler */
+    errno = error;
+
+#endif
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /*DIRENT_H*/
+

--- a/codebase/compat/win32/strcasestr.h
+++ b/codebase/compat/win32/strcasestr.h
@@ -1,0 +1,74 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _STRCASESTR_H_
+#define _STRCASESTR_H_
+
+#include <ctype.h>
+#include <string.h>
+
+#ifndef HAVE_STRCASESTR
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline char* strcasestr(const char *s, const char *find)
+{
+  char c, sc;
+  size_t len;
+  
+  if ((c = *find++) != 0) {
+    c = tolower((unsigned char)c);
+    len = strlen(find);
+    do {
+      do {
+        if ((sc = *s++) == 0)
+          return (NULL);
+      } while ((char)tolower((unsigned char)sc) != c);
+    } while (_strnicmp(s, find, len) != 0);
+    s--;
+  }
+  return ((char *)s);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif

--- a/codebase/libs/Ncxx/CMakeLists.txt
+++ b/codebase/libs/Ncxx/CMakeLists.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(Ncxx)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../../cmake/")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS False)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# -----------------------------------------------------------------------------
+# External Dependencies
+# -----------------------------------------------------------------------------
+
+set(NETCDF_CXX True)
+find_package(NetCDF REQUIRED)
+include_directories(${NETCDF_INCLUDE_DIRS})
+# Link: NETCDF_LIBRARIES
+
+set(HDF5_USE_STATIC_LIBRARIES True)
+find_package(HDF5 COMPONENTS C CXX REQUIRED)
+include_directories(${HDF5_INCLUDE_DIRS})
+# Link: HDF5_LIBRARIES
+
+find_package(UDUnits REQUIRED)
+include_directories(${UDUNITS_INCLUDE_DIR})
+# Link: UDUNITS_LIBRARY
+
+find_package(BZip2 REQUIRED)
+include_directories(${BZIP2_INCLUDE_DIR})
+# Link: BZIP2_LIBRARIES
+
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIRS})
+# Link: ZLIB_LIBRARIES
+
+if(MSVC)
+  include_directories(${CMAKE_SOURCE_DIR}/../../compat/win32)
+  
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  
+  # Check for pthreads-win32
+  set(THREADS_USE_PTHREADS_WIN32 True)
+  find_package(Threads)
+  if(NOT THREADS_FOUND)
+    message(FATAL_ERROR "MSVC build requires pthreads-win32.")
+  else()
+    include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+	# Avoid redefinition of 'struct timespec' with pthreads-win32
+    add_definitions(-DHAVE_STRUCT_TIMESPEC)
+  endif()
+endif()
+
+# Expose macro definitions for math constants
+add_definitions(-D_USE_MATH_DEFINES)
+
+# -----------------------------------------------------------------------------
+# Targets
+# -----------------------------------------------------------------------------
+
+add_subdirectory("src")

--- a/codebase/libs/Ncxx/src/CMakeLists.txt
+++ b/codebase/libs/Ncxx/src/CMakeLists.txt
@@ -1,0 +1,38 @@
+list(APPEND SOURCES
+  Ncxx/Ncxx.cc
+  Ncxx/NcxxAtt.cc
+  Ncxx/NcxxByte.cc
+  Ncxx/NcxxChar.cc
+  Ncxx/NcxxCheck.cc
+  Ncxx/NcxxCompoundType.cc
+  Ncxx/NcxxDim.cc
+  Ncxx/NcxxDouble.cc
+  Ncxx/NcxxEnumType.cc
+  Ncxx/NcxxErrStr.cc
+  Ncxx/NcxxException.cc
+  Ncxx/NcxxFile.cc
+  Ncxx/NcxxFloat.cc
+  Ncxx/NcxxGroup.cc
+  Ncxx/NcxxGroupAtt.cc
+  Ncxx/NcxxInt.cc
+  Ncxx/NcxxInt64.cc
+  Ncxx/NcxxOpaqueType.cc
+  Ncxx/NcxxShort.cc
+  Ncxx/NcxxString.cc
+  Ncxx/NcxxType.cc
+  Ncxx/NcxxUbyte.cc
+  Ncxx/NcxxUint.cc
+  Ncxx/NcxxUint64.cc
+  Ncxx/NcxxUshort.cc
+  Ncxx/NcxxVar.cc
+  Ncxx/NcxxVarAtt.cc
+  Ncxx/NcxxVlenType.cc
+)
+
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+add_library(Ncxx ${SOURCES})
+target_link_libraries(Ncxx ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${UDUNITS_LIBRARY} ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES})
+if(MSVC)
+  target_link_libraries(Ncxx ${THREADS_PTHREADS_WIN32_LIBRARY})
+endif()

--- a/codebase/libs/Ncxx/src/include/Ncxx/Ncxx.hh
+++ b/codebase/libs/Ncxx/src/include/Ncxx/Ncxx.hh
@@ -53,7 +53,7 @@
 // global include file for the Ncxx C++ API
 
 #include <string>
-#include <sys/types.h>
+#include <cstdint>
 using namespace std;
 
 extern "C" {
@@ -112,11 +112,11 @@ public:
   typedef char si08;
   typedef unsigned char ui08;
   typedef int16_t si16;
-  typedef u_int16_t ui16;
+  typedef uint16_t ui16;
   typedef int32_t si32;
-  typedef u_int32_t ui32;
+  typedef uint32_t ui32;
   typedef int64_t si64;
-  typedef u_int64_t ui64;
+  typedef uint64_t ui64;
   typedef float fl32;
   typedef double fl64;
 

--- a/codebase/libs/Ncxx/src/include/Ncxx/NcxxPort.hh
+++ b/codebase/libs/Ncxx/src/include/Ncxx/NcxxPort.hh
@@ -36,7 +36,7 @@
 #ifndef NcxxPort_HH
 #define NcxxPort_HH
 
-#include <sys/types.h>
+#include <cstdint>
 using namespace std;
 
 //////////////////////////////////////////////////////////////////////
@@ -93,11 +93,11 @@ public:
   typedef char si08; ///< portable unsigned 8-bit integer
   typedef unsigned char ui08; ///< portable unsigned 8-bit integer
   typedef int16_t si16; ///< portable signed 16-bit integer
-  typedef u_int16_t ui16; ///< portable unsigned 16-bit integer
+  typedef uint16_t ui16; ///< portable unsigned 16-bit integer
   typedef int32_t si32; ///< portable signed 32-bit integer
-  typedef u_int32_t ui32; ///< portable unsigned 32-bit integer
+  typedef uint32_t ui32; ///< portable unsigned 32-bit integer
   typedef int64_t si64; ///< portable signed 32-bit integer
-  typedef u_int64_t ui64; ///< portable unsigned 32-bit integer
+  typedef uint64_t ui64; ///< portable unsigned 32-bit integer
   typedef float fl32; ///< portable 32-bit IEEE float
   typedef double fl64; ///< portable 64-bit IEEE float
 

--- a/codebase/libs/Radx/CMakeLists.txt
+++ b/codebase/libs/Radx/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(Radx)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../../cmake/")
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS False)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# -----------------------------------------------------------------------------
+# Radx Modules
+# -----------------------------------------------------------------------------
+
+option(Module_CfRadial "Cf/Radial netCDF support" ON)
+option(Module_CfRadial2 "Cf/Radial 2 netCDF support" ON)
+option(Module_D3R "CSU/NASA D3R netCDF support" ON)
+option(Module_DOE "DOE netCDF (early) support" ON)
+option(Module_DORADE "NCAR/EOL DORADE support" ON)
+option(Module_EEC "EDGE netCDF format" ON)
+option(Module_FORAY "NCAR/EOL FORAY netCDF support" ON)
+option(Module_GAMIC "GAMIC HDF5 support" ON)
+option(Module_Gematronik "Gematronik support" ON)
+option(Module_HRD "HRD raw support" OFF)
+option(Module_Leosphere "Leosphere support" ON)
+option(Module_MRD "NSSL MRD support" ON)
+option(Module_NEXRAD "NEXRAD level II support" ON)
+option(Module_NOXP "OU NOXP support" ON)
+option(Module_ODIM "ODIM HDF5 support" ON)
+option(Module_RAPIC "RAPIC (BOM) support" ON)
+option(Module_SIGMET "SIGMET RAW support" ON)
+option(Module_TDWR "TDWR support" ON)
+option(Module_TWOLF "TWOLF support" ON)
+option(Module_UF "UF support" ON)
+
+# -----------------------------------------------------------------------------
+# External Dependencies
+# -----------------------------------------------------------------------------
+
+set(NETCDF_CXX True)
+find_package(NetCDF REQUIRED)
+include_directories(${NETCDF_INCLUDE_DIRS})
+# Link: NETCDF_LIBRARIES
+
+set(HDF5_USE_STATIC_LIBRARIES True)
+find_package(HDF5 COMPONENTS C CXX REQUIRED)
+include_directories(${HDF5_INCLUDE_DIRS})
+# Link: HDF5_LIBRARIES
+
+find_package(UDUnits REQUIRED)
+include_directories(${UDUNITS_INCLUDE_DIR})
+# Link: UDUNITS_LIBRARY
+
+find_package(BZip2 REQUIRED)
+include_directories(${BZIP2_INCLUDE_DIR})
+# Link: BZIP2_LIBRARIES
+
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIRS})
+# Link: ZLIB_LIBRARIES
+
+if(MSVC)
+  include_directories(${CMAKE_SOURCE_DIR}/../../compat/win32)
+  
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  
+  # Check for pthreads-win32
+  set(THREADS_USE_PTHREADS_WIN32 True)
+  find_package(Threads)
+  if(NOT THREADS_FOUND)
+    message(FATAL_ERROR "MSVC build requires pthreads-win32.")
+  else()
+    include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+	# Avoid redefinition of 'struct timespec' with pthreads-win32
+    add_definitions(-DHAVE_STRUCT_TIMESPEC)
+  endif()
+endif()
+
+# Expose macro definitions for math constants
+add_definitions(-D_USE_MATH_DEFINES)
+
+# -----------------------------------------------------------------------------
+# Targets
+# -----------------------------------------------------------------------------
+
+add_subdirectory("src")

--- a/codebase/libs/Radx/src/CMakeLists.txt
+++ b/codebase/libs/Radx/src/CMakeLists.txt
@@ -1,0 +1,189 @@
+list(APPEND SOURCES
+  Radx/ByteOrder.cc
+  Radx/PseudoRhi.cc
+  Radx/Radx.cc
+  Radx/RadxAngleHist.cc
+  Radx/RadxAzElev.cc
+  Radx/RadxBuf.cc
+  Radx/RadxCfactors.cc
+  Radx/RadxComplex.cc
+  Radx/RadxEvent.cc
+  Radx/RadxField.cc
+  Radx/RadxFile.cc
+  Radx/RadxFuzzy2d.cc
+  Radx/RadxFuzzyF.cc
+  Radx/RadxGeoref.cc
+  Radx/RadxMsg.cc
+  Radx/RadxPacking.cc
+  Radx/RadxPath.cc
+  Radx/RadxPlatform.cc
+  Radx/RadxRangeGeom.cc
+  Radx/RadxRay.cc
+  Radx/RadxRcalib.cc
+  Radx/RadxReadDir.cc
+  Radx/RadxRemap.cc
+  Radx/RadxStr.cc
+  Radx/RadxSweep.cc
+  Radx/RadxTime.cc
+  Radx/RadxTimeList.cc
+  Radx/RadxVol.cc
+  Radx/RadxXml.cc
+  Radx/RayxData.cc
+  Radx/RayxMapping.cc
+)
+
+if(Module_CfRadial)
+  list(APPEND SOURCES
+    Ncf/NcfRadxFile.cc
+    Ncf/NcfRadxFile_read.cc
+    Ncf/NcfRadxFile_write.cc
+    Ncf/NcxxRadxFile.cc
+    Ncf/NcxxRadxFile_read.cc
+    Ncf/NcxxRadxFile_write.cc
+  )
+endif()
+
+if(Module_CfRadial2)
+  list(APPEND SOURCES
+    Cf2/Cf2RadxFile.cc
+	Cf2/Cf2RadxFile_read.cc
+	Cf2/Cf2RadxFile_write.cc
+  )
+endif()
+
+if(Module_D3R)
+  list(APPEND SOURCES
+    D3R/D3rNcRadxFile.cc
+  )
+endif()
+
+if(Module_DOE)
+  list(APPEND SOURCES
+    DOE/DoeNcRadxFile.cc
+  )
+endif()
+
+if(Module_DORADE)
+  list(APPEND SOURCES
+    Dorade/DoradeData.cc
+    Dorade/DoradeRadxFile.cc
+  )
+endif()
+
+if(Module_EEC)
+  list(APPEND SOURCES
+    EEC/EdgeNcRadxFile.cc
+  )
+endif()
+
+if(Module_FORAY)
+  list(APPEND SOURCES
+    ForayNc/ForayNcRadxFile.cc
+    ForayNc/ForayNcRadxFile_read.cc
+    ForayNc/ForayNcRadxFile_write.cc
+  )
+endif()
+
+if(Module_GAMIC)
+  list(APPEND SOURCES
+    Gamic/GamicHdf5RadxFile.cc
+  )
+endif()
+
+if(Module_Gematronik)
+  list(APPEND SOURCES
+    Gematronik/GemBlob.cc
+    Gematronik/GemRadxFile.cc
+    Gematronik/GemInputField.cc
+    Gematronik/GemSweep.cc
+  )
+endif()
+
+if(Module_HRD)
+  list(APPEND SOURCES
+    Hrd/HrdData.cc
+    Hrd/HrdRadxFile.cc  
+  )
+endif()
+
+if(Module_Leosphere)
+  list(APPEND SOURCES
+    Leosphere/LeoRadxFile.cc
+  )
+endif()
+
+if(Module_MRD)
+  list(APPEND SOURCES
+    NsslMrd/NsslMrdRadxFile.cc
+  )
+endif()
+
+if(Module_NEXRAD)
+  list(APPEND SOURCES
+    Nexrad/NexradCmdRadxFile.cc
+    Nexrad/NexradData.cc
+    Nexrad/NexradLoc.cc
+    Nexrad/NexradRadxFile.cc
+    Nexrad/NexradVcp.cc
+    Nexrad/NidsData.cc
+    Nexrad/NidsRadxFile.cc
+  )
+endif()
+
+if(Module_NOXP)
+  list(APPEND SOURCES
+    Noxp/NoxpNcRadxFile.cc
+  )
+endif()
+
+if(Module_ODIM)
+  list(APPEND SOURCES
+    Odim/OdimHdf5RadxFile.cc
+  )
+endif()
+
+if(Module_RAPIC)
+  list(APPEND SOURCES
+    Rapic/Linebuff.cc
+    Rapic/PPIField.cc
+    Rapic/RapicRadxFile.cc
+    Rapic/RapicRay.cc
+    Rapic/ScanParams.cc
+    Rapic/sRadl.cc
+  )
+endif()
+
+if(Module_SIGMET)
+  list(APPEND SOURCES
+    Sigmet/SigmetRadxFile.cc
+  )
+endif()
+
+if(Module_TDWR)
+  list(APPEND SOURCES
+    Tdwr/TdwrLoc.cc
+    Tdwr/TdwrRadxFile.cc
+  )
+endif()
+
+if(Module_TWOLF)
+  list(APPEND SOURCES
+    Twolf/TwolfRadxFile.cc
+  )
+endif()
+
+if(Module_UF)
+  list(APPEND SOURCES
+    Uf/UfData.cc
+    Uf/UfRadxFile.cc
+  )
+endif()
+
+include_directories(. ${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_SOURCE_DIR}/../Ncxx/src/include)
+
+add_library(Radx ${SOURCES})
+target_link_libraries(Radx ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${UDUNITS_LIBRARY} ${HDF5_LIBRARIES} ${NETCDF_LIBRARIES})
+if(MSVC)
+  target_link_libraries(Radx ${THREADS_PTHREADS_WIN32_LIBRARY})
+endif()

--- a/codebase/libs/Radx/src/Cf2/Cf2RadxFile_write.cc
+++ b/codebase/libs/Radx/src/Cf2/Cf2RadxFile_write.cc
@@ -44,7 +44,12 @@
 #include <Radx/RadxPath.hh>
 #include <Radx/RadxArray.hh>
 #include <Radx/RadxStr.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#include <strcasestr.h>
+#else
 #include <unistd.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <cmath>
@@ -52,6 +57,10 @@
 #include <dirent.h>
 #include <algorithm>
 using namespace std;
+
+#ifdef _MSC_VER
+#define unlink(filename) _unlink(filename)
+#endif
 
 /////////////////////////////////////////////////////////
 // Write data from volume to specified directory

--- a/codebase/libs/Radx/src/Dorade/DoradeData.cc
+++ b/codebase/libs/Radx/src/Dorade/DoradeData.cc
@@ -849,8 +849,8 @@ void DoradeData::print(const DoradeData::radar_t &val, ostream &out)
   out << "  radar_type: " << radarTypeToStr((radar_type_t) val.radar_type) << endl;
   out << "  scan_mode: " << scanModeToStr((scan_mode_t) val.scan_mode) << endl;
   out << "  req_rotat_vel: " << val.req_rotat_vel << endl;
-  out << "  scan_mode_pram0: " << scanModeToStr((scan_mode_t) val.scan_mode_pram0) << endl;
-  out << "  scan_mode_pram1: " << scanModeToStr((scan_mode_t) val.scan_mode_pram1) << endl;
+  out << "  scan_mode_pram0: " << scanModeToStr((scan_mode_t) (int)val.scan_mode_pram0) << endl;
+  out << "  scan_mode_pram1: " << scanModeToStr((scan_mode_t) (int)val.scan_mode_pram1) << endl;
   out << "  num_parameter_des: " << val.num_parameter_des << endl;
   out << "  total_num_des: " << val.total_num_des << endl;
   out << "  data_compress: " << val.data_compress << endl;

--- a/codebase/libs/Radx/src/ForayNc/ForayNcRadxFile_write.cc
+++ b/codebase/libs/Radx/src/ForayNc/ForayNcRadxFile_write.cc
@@ -44,7 +44,13 @@
 #include <Radx/RadxGeoref.hh>
 #include <Radx/RadxSweep.hh>
 #include <Radx/RadxPath.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#include <direct.h>
+#else
 #include <unistd.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <cmath>

--- a/codebase/libs/Radx/src/Ncf/NcfRadxFile_write.cc
+++ b/codebase/libs/Radx/src/Ncf/NcfRadxFile_write.cc
@@ -44,7 +44,12 @@
 #include <Radx/RadxPath.hh>
 #include <Radx/RadxArray.hh>
 #include <Radx/RadxStr.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#include <strcasestr.h>
+#else
 #include <unistd.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <cmath>

--- a/codebase/libs/Radx/src/Ncf/NcxxRadxFile_write.cc
+++ b/codebase/libs/Radx/src/Ncf/NcxxRadxFile_write.cc
@@ -44,7 +44,12 @@
 #include <Radx/RadxPath.hh>
 #include <Radx/RadxArray.hh>
 #include <Radx/RadxStr.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#include <strcasestr.h>
+#else
 #include <unistd.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <cmath>

--- a/codebase/libs/Radx/src/Nexrad/NexradRadxFile.cc
+++ b/codebase/libs/Radx/src/Nexrad/NexradRadxFile.cc
@@ -50,17 +50,27 @@
 #include <Radx/RadxRcalib.hh>
 #include <Radx/RadxStr.hh>
 #include <Radx/RadxReadDir.hh>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <cmath>
 #include <cerrno>
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#include <direct.h>
+#else
 #include <unistd.h>
+#endif
 #include <dirent.h>
 #include <algorithm>
 #include <bzlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <arpa/inet.h>
 using namespace std;
 
 const double NexradRadxFile::_prtTable[5][8] =

--- a/codebase/libs/Radx/src/Nexrad/NidsRadxFile.cc
+++ b/codebase/libs/Radx/src/Nexrad/NidsRadxFile.cc
@@ -58,7 +58,6 @@
 #include <algorithm>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <arpa/inet.h>
 #include <bzlib.h>
 using namespace std;
 

--- a/codebase/libs/Radx/src/Radx/RadxFile.cc
+++ b/codebase/libs/Radx/src/Radx/RadxFile.cc
@@ -62,11 +62,27 @@
 #include <Radx/RadxVol.hh>
 #include <Ncxx/Hdf5xx.hh>
 #include <Radx/RadxSweep.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#include <direct.h>
+#else
 #include <unistd.h>
+#endif
 #include <cstring>
 #include <cstdio>
 #include <sys/stat.h>
 using namespace std;
+
+#ifdef _MSC_VER
+// Replacement for POSIX mkdir. Ignore mode argument.
+#define S_IRWXU 0
+#define S_IRWXG 0
+#define S_IROTH 0
+#define S_IXOTH 0
+#define mkdir(D, M) _mkdir(D)
+#define getpid() _getpid()
+#endif
 
 const char *RadxFile::PATH_SEPARATOR = "/";
 

--- a/codebase/libs/Radx/src/Radx/RadxPath.cc
+++ b/codebase/libs/Radx/src/Radx/RadxPath.cc
@@ -32,10 +32,25 @@
 
 #include <iostream>
 #include <cstdio>
+#ifdef _MSC_VER
+#include <io.h>
+#include <process.h>
+#include <direct.h>
+#else
 #include <unistd.h>
+#endif
 #include <sys/stat.h>
 #include <Radx/RadxPath.hh>
 using namespace std;
+
+#ifdef _MSC_VER
+// Replacement for POSIX mkdir. Ignore mode argument.
+#define S_IRWXU 0
+#define S_IRWXG 0
+#define S_IROTH 0
+#define S_IXOTH 0
+#define mkdir(D, M) _mkdir(D)
+#endif
 
 // static definitions
 

--- a/codebase/libs/Radx/src/Radx/RadxReadDir.cc
+++ b/codebase/libs/Radx/src/Radx/RadxReadDir.cc
@@ -33,7 +33,11 @@
 ////////////////////////////////////////////////////////////////////
 
 #include <Radx/RadxReadDir.hh>
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 #include <cerrno>
 using namespace std;
 
@@ -82,8 +86,12 @@ int RadxReadDir::open(const char *dir_path)
   
   // reserve buffer for the results
 
+#ifdef _WIN32
+  int bufSize = sizeof(struct  dirent) + 260; // MAX_PATH
+#else
   int bufSize =
     sizeof(struct  dirent) + pathconf(dir_path, _PC_NAME_MAX) + 1;
+#endif
   _buf.reserve(bufSize);
   
   if ((_dirp = opendir(dir_path)) == NULL) {
@@ -101,7 +109,7 @@ struct dirent *RadxReadDir::read()
   
 {
   
-#if defined(SUNOS5) || defined (SUNOS5_INTEL)
+#if defined(SUNOS5) || defined (SUNOS5_INTEL) || defined (_WIN32)
   return (readdir(_dirp));
 #else
   struct dirent *result;

--- a/codebase/libs/Radx/src/Radx/RadxTime.cc
+++ b/codebase/libs/Radx/src/Radx/RadxTime.cc
@@ -36,7 +36,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <ctype.h>
-#include <sys/time.h>
+#include <chrono>
 #include <vector>
 #include <Radx/RadxTime.hh>
 using namespace std;
@@ -158,11 +158,14 @@ void RadxTime::clear()
 void RadxTime::set(SpecifyTime_t spec)
 {
   switch(spec) {
-    case NOW:
-      struct timeval tv;
-      gettimeofday(&tv, NULL);
-      _uTime = tv.tv_sec;
-      _subSec = tv.tv_usec / 1.0e6;
+  case NOW: {
+      auto tval = chrono::system_clock::now();
+      auto duration = tval.time_since_epoch();
+      auto sec = chrono::duration_cast<chrono::seconds>(duration);
+      auto usec = chrono::duration_cast<chrono::microseconds>(duration - sec);
+      _uTime = chrono::system_clock::to_time_t(tval);
+      _subSec = chrono::duration<double>(usec).count();
+      }
       break;
     case ZERO:
     default:
@@ -549,12 +552,12 @@ string RadxTime::asStringDashed(int subsecPrecision /* = 0*/) const
 //////////////////////////////////////
 // get current time as double secs
 
-double RadxTime::getCurrentTimeAsDouble()
-  
+double RadxTime::getCurrentTimeAsDouble() 
 {
-  struct timeval tval;
-  gettimeofday(&tval, NULL);
-  return (tval.tv_sec + tval.tv_usec / 1000000.0);
+  auto tval = chrono::system_clock::now();
+  auto duration = tval.time_since_epoch();
+  auto sec = chrono::duration_cast<chrono::seconds>(duration);
+  return std::chrono::duration<double>(sec).count();
 }
 
 

--- a/codebase/libs/Radx/src/Sigmet/SigmetRadxFile.cc
+++ b/codebase/libs/Radx/src/Sigmet/SigmetRadxFile.cc
@@ -57,6 +57,10 @@
 #include <algorithm>
 using namespace std;
 
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
+
 const double SigmetRadxFile::_angleConversion = 360.0 / 65536.0;
 int SigmetRadxFile::_volumeNumber = 0;
  

--- a/codebase/libs/Radx/src/include/Radx/DoradeData.hh
+++ b/codebase/libs/Radx/src/include/Radx/DoradeData.hh
@@ -257,7 +257,7 @@ public:
   ////////////////////////////////////////////////////
   /// Comment block - COMM
 
-  typedef struct comment {
+  typedef struct comment_t {
 
     char id[4];  /**< Comment descriptor identifier: ASCII
                   * characters "COMM" stand for Comment

--- a/codebase/libs/Radx/src/include/Radx/Radx.hh
+++ b/codebase/libs/Radx/src/include/Radx/Radx.hh
@@ -39,7 +39,7 @@
 #define Radx_HH
 
 #include <string>
-#include <sys/types.h>
+#include <cstdint>
 using namespace std;
 
 //////////////////////////////////////////////////////////////////////
@@ -237,11 +237,11 @@ public:
   typedef char si08; ///< portable unsigned 8-bit integer
   typedef unsigned char ui08; ///< portable unsigned 8-bit integer
   typedef int16_t si16; ///< portable signed 16-bit integer
-  typedef u_int16_t ui16; ///< portable unsigned 16-bit integer
+  typedef uint16_t ui16; ///< portable unsigned 16-bit integer
   typedef int32_t si32; ///< portable signed 32-bit integer
-  typedef u_int32_t ui32; ///< portable unsigned 32-bit integer
+  typedef uint32_t ui32; ///< portable unsigned 32-bit integer
   typedef int64_t si64; ///< portable signed 32-bit integer
-  typedef u_int64_t ui64; ///< portable unsigned 32-bit integer
+  typedef uint64_t ui64; ///< portable unsigned 32-bit integer
   typedef float fl32; ///< portable 32-bit IEEE float
   typedef double fl64; ///< portable 64-bit IEEE float
 


### PR DESCRIPTION
This adds support for building a native Radx library for Windows using MSVC 14.0 (Visual Studio 2015) and CMake. I am currently able to build Ncxx and Radx as static libraries and use basic functions as in [RadxTest.cc](https://github.com/NCAR/lrose-core/blob/626c257f146e69159301a0256e164a22287d4e75/codebase/apps/Radx/src/RadxTest/RadxTest.cc).

Other than the build system, few changes needed to be made, summarized below:

- Replaced <arpa/inet.h> with <winsock2.h>, which is just used for network-to-host byte order conversions and vice-versa, e.g. `ntohs()`.
- Replaced <sys/types.h> with <cstdint> and change typedefs to use C++ standard integer types.
- Replaced code using POSIX `gettimeofday()` function for wall clock time with new C++11 code based on std::chrono, in [`RadxTime::set`](https://github.com/NCAR/lrose-core/blob/626c257f146e69159301a0256e164a22287d4e75/codebase/libs/Radx/src/Radx/RadxTime.cc#L158-L171) and [`RadxTime::getCurrentTimeAsDouble`](https://github.com/NCAR/lrose-core/blob/626c257f146e69159301a0256e164a22287d4e75/codebase/libs/Radx/src/Radx/RadxTime.cc#L552-L558). Other approaches are possible here.
- Added some compatibility headers implementing `strcasestr()`, based on [strcasestr.c](https://github.com/freebsd/freebsd/blob/master/contrib/file/src/strcasestr.c) in FreeBSD, and dirent.h from [tronkko/dirent](https://github.com/tronkko/dirent). I wasn't sure where to fit these in the project structure, so I just put them under codebase/compat.

I am using the following versions of external dependencies, all built as static libraries in release mode with CMake:

 - bzip2 1.0.6
 - HDF5 1.8.19
 - netCDF-C 4.4.1.1
 - netCDF-4 C++ 4.3.0
 - UDUNITS 2.2.25
 - Expat 2.2.1

Also required is an implementation of pthreads for Win32. I am using [pthreads-win32 from sourceware.org](https://www.sourceware.org/pthreads-win32/).

Remaining items:

- [ ] Add CMakeLists.txt files for subdirectories in Radx/src/ and Ncxx/src/, to match current style of having Makefile in individual source directories.
- [ ] Remove dependency on pthreads. Since Radx mainly just uses mutexes from pthreads, I should be able to make those call Win32 API equivalents, e.g. `pthread_mutex_lock` becomes `[EnterCriticalSection](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682608(v=vs.85).aspx)`.
- [ ] Start work on porting some of the Radx applications e.g. RadxConvert. This will likely be a bit more difficult.

This work is still at an early stage, but review and comments on this pull request are much appreciated. 

Thank you for your work on this nice library and making it available to the weather community.

John