### PR TITLE
Update Ascii2Radx.cc

### DIFF
--- a/codebase/apps/Radx/src/Ascii2Radx/Ascii2Radx.cc
+++ b/codebase/apps/Radx/src/Ascii2Radx/Ascii2Radx.cc
@@ -704,7 +704,7 @@ void Ascii2Radx::_finalizeVol(RadxVol &vol)
   if (_params.debug) {
     cerr << "DEBUG - computing sweep fixed angles from ray data" << endl;
   }
-  vol.computeSweepFixedAnglesFromRays();
+  vol.computeFixedAnglesFromRays();
 
   // sweep limits
   


### PR DESCRIPTION
The vol.computeFixedAnglesFromRays function in Ascii2Radx.cc is outdated.