### PR TITLE
lrose-core Issue #49: Added missing function call parameters (nullptr).

### DIFF
--- a/codebase/apps/radar/src/SpectraPlot/spectra_plot.cc
+++ b/codebase/apps/radar/src/SpectraPlot/spectra_plot.cc
@@ -1890,6 +1890,7 @@ static void load_plot_data_single_prt()
                               iqWindowed, NULL,
                               _spectra.getNoise() / rcvGain,
                               filtWindowed,
+                              nullptr, // *iqNotched
                               filterRatio,
                               spectralNoise,
                               spectralSnr);
@@ -1936,6 +1937,7 @@ static void load_plot_data_single_prt()
                                 _spectra.getNoise() - rcvGainDb,
                                 _params->regression_interp_across_notch,
                                 regrFiltered,
+                                nullptr, // *iqNotched
                                 regrFilterRatio,
                                 regrSpectralNoise,
                                 regrSpectralSnr);

--- a/codebase/apps/radar/src/SpectraScope/spectra_plot.cc
+++ b/codebase/apps/radar/src/SpectraScope/spectra_plot.cc
@@ -1845,6 +1845,7 @@ static void load_plot_data_single_prt()
   moments.applyAdaptiveFilter(_nSamples, fft, iqWindowed, NULL,
                               _spectra.getNoise() / rcvGain,
                               filtWindowed,
+                              nullptr, // *iqNotched
                               filterRatio,
                               spectralNoise,
                               spectralSnr);
@@ -1891,6 +1892,7 @@ static void load_plot_data_single_prt()
                                 _spectra.getNoise() - rcvGainDb,
                                 _params->regression_interp_across_notch,
                                 regrFiltered,
+                                nullptr, // *iqNotched
                                 regrFilterRatio,
                                 regrSpectralNoise,
                                 regrSpectralSnr);


### PR DESCRIPTION
Mike,

A new parameter (iqNotched) was added to RadarMoments::applyAdaptiveFilter() and RadarMoments::applyRegressionFilter() in include/radar/RadarMoments.hh that breaks the CIDD 32-bit build.  

This parameter is missing from calls in apps/radar/src/SpectraPlot/spectra_plot.cc and apps/radar/src/SpectraScope/spectra_plot.cc.

I added a nullptr argument to each of the missing calls and verified the CIDD 32-bit build  with:

- ./build/autoconf/run_autoconf.cidd

- ./build/build_lrose.py  --package cidd --prefix /tmp/cidd_m32

