### PR TITLE
Use text color param for RHI plot legend

### DIFF
--- a/codebase/apps/radar/src/HawkEye/RhiWidget.cc
+++ b/codebase/apps/radar/src/HawkEye/RhiWidget.cc
@@ -574,7 +574,7 @@ void RhiWidget::_drawOverlays(QPainter &painter)
     legends.push_back(text);
     
     painter.save();
-    painter.setPen(Qt::yellow);
+    painter.setPen(QColor(_params.text_color)); //Qt::yellow);
     painter.setBrush(Qt::black);
     painter.setBackgroundMode(Qt::OpaqueMode);
 


### PR DESCRIPTION
This was fixed for ppi plots, but not rhi.