### PR TITLE
Update the configuration to support Cray and Fujitsu compilers

### DIFF
--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -616,6 +616,8 @@ def writeCMakeListsTop(dir):
 
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
+    elif (options.isfujitsu):
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -D_DEFAULT_SOURCE ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -512,8 +512,8 @@ def writeCMakeListsTop(dir):
     fo.write('endif()\n')
     fo.write('\n')
 
-    fo.write('set(CMAKE_C_COMPILER_NAMES clang gcc icc cc)\n')
-    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ g++ icpc c++ cxx)\n')
+    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
+    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
     fo.write('\n')
 
     if (options.verboseMake):

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,7 +618,7 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
  
     if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 -D__linux__ ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,12 +613,12 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC -std=c11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC -std=c17 ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -std=c++11 -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -std=c++17 ")\n')
         
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -515,8 +515,8 @@ def writeCMakeListsTop(dir):
 #    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
 #    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
     
-    fo.write('set(CMAKE_C_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
-    fo.write('set(CMAKE_CXX_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
+    fo.write('set(CMAKE_C_COMPILER fcc)\n')
+    fo.write('set(CMAKE_CXX_COMPILER FCC)\n')
     fo.write('\n')
 
     if (options.verboseMake):

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,14 +618,14 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
  
     if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu17 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++17 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -616,7 +616,8 @@ def writeCMakeListsTop(dir):
 
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
-    elif (options.isfujitsu):
+ 
+    if (options.isfujitsu):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
@@ -624,7 +625,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++11 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -512,11 +512,8 @@ def writeCMakeListsTop(dir):
     fo.write('endif()\n')
     fo.write('\n')
 
-#    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
-#    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
-
-    fo.write('set(CMAKE_C_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
-    fo.write('set(CMAKE_CXX_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
+    fo.write('set(CMAKE_C_COMPILER_NAMES clang gcc icc cc fcc)\n')
+    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ g++ icpc c++ cxx FCC CC)\n')
     fo.write('\n')
 
     if (options.verboseMake):
@@ -618,7 +615,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,14 +618,14 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
  
     if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c++03 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++11 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++03 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -92,6 +92,10 @@ def main():
                       dest='withJasper', default=False,
                       action="store_true",
                       help='Set if jasper library is installed. This provides support for jpeg compression in grib files.')
+    parser.add_option('--iscray',
+                      dest='iscray', default=False,
+                      action="store_true",
+                      help='True if the Cray compiler is used')
 
     (options, args) = parser.parse_args()
 
@@ -608,7 +612,10 @@ def writeCMakeListsTop(dir):
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
-    fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
+    if (options.iscray):
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
+    else:
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -486,6 +486,9 @@ def writeCMakeListsTop(dir):
               dir, file=sys.stderr)
         print("     ", cmakePath, file=sys.stderr)
 
+    runCommand('export CC=/opt/FJSVstclanga/cp-1.0.20.06/bin/fcc')
+    runCommand('export CXX=/opt/FJSVstclanga/cp-1.0.20.06/bin/FCC')
+    
     fo = open(cmakePath, 'w')
 
     fo.write("###############################################################\n")
@@ -515,8 +518,6 @@ def writeCMakeListsTop(dir):
 #    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
 #    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
 
-    fo.write('set(CC /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
-    fo.write('set(CXX /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
     fo.write('set(CMAKE_C_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
     fo.write('set(CMAKE_CXX_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
     fo.write('\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -625,7 +625,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 -D__linux__ ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -183,7 +183,7 @@ def main():
         print("==>>   nTotal  : ", nTotal, file=sys.stderr)
         
     # sanity check: we could not use Cray and Fujitsu compilers at the same time
-    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True")
+    assert not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True..."
         
     sys.exit(0)
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 -lsci_cray ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -512,8 +512,11 @@ def writeCMakeListsTop(dir):
     fo.write('endif()\n')
     fo.write('\n')
 
-    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
-    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
+#    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
+#    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
+    
+    fo.write('set(CMAKE_C_COMPILER fcc)\n')
+    fo.write('set(CMAKE_CXX_COMPILER FCC)\n')
     fo.write('\n')
 
     if (options.verboseMake):

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu99 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,7 +618,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -std=c++11 -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
         
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c++11 ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -515,8 +515,8 @@ def writeCMakeListsTop(dir):
 #    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
 #    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
     
-    fo.write('set(CMAKE_C_COMPILER fcc)\n')
-    fo.write('set(CMAKE_CXX_COMPILER FCC)\n')
+    fo.write('set(CMAKE_C_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
+    fo.write('set(CMAKE_CXX_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
     fo.write('\n')
 
     if (options.verboseMake):

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC -std=c11 ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -622,7 +622,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++14 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 -D__fujitsu__ ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -183,7 +183,7 @@ def main():
         print("==>>   nTotal  : ", nTotal, file=sys.stderr)
         
     # sanity check: we could not use Cray and Fujitsu compilers at the same time
-    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True)
+    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True")
         
     sys.exit(0)
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -514,7 +514,9 @@ def writeCMakeListsTop(dir):
 
 #    fo.write('set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)\n')
 #    fo.write('set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)\n')
-    
+
+    fo.write('set(CC /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
+    fo.write('set(CXX /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
     fo.write('set(CMAKE_C_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/fcc)\n')
     fo.write('set(CMAKE_CXX_COMPILER /opt/FJSVstclanga/cp-1.0.20.06/bin/FCC)\n')
     fo.write('\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -605,6 +605,8 @@ def writeCMakeListsTop(dir):
 
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
+    else:
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
     if (options.m32):

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c14 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,12 +613,12 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC -std=c17 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c14 ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -std=c++17 ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ")\n')
         
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,7 +618,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     else:
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
         
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -KPIC -D_DEFAULT_SOURCE ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -D_DEFAULT_SOURCE ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -96,7 +96,11 @@ def main():
                       dest='iscray', default=False,
                       action="store_true",
                       help='True if the Cray compiler is used')
-
+    parser.add_option('--isfujitsu',
+                      dest='isfujitsu', default=False,
+                      action="store_true",
+                      help='True if the Fujitsu compiler is used')
+    
     (options, args) = parser.parse_args()
 
     if (options.verbose):
@@ -177,7 +181,10 @@ def main():
         print("==>>   nApps   : ", nApps, file=sys.stderr)
         print("==>>   nOther  : ", nOther, file=sys.stderr)
         print("==>>   nTotal  : ", nTotal, file=sys.stderr)
-
+        
+    # sanity check: we could not use Cray and Fujitsu compilers at the same time
+    expect (not (options.iscray and options.isfujitsu), "iscray and isfujitsu could not be both True)
+        
     sys.exit(0)
 
 ########################################################################
@@ -614,6 +621,8 @@ def writeCMakeListsTop(dir):
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
+    elif (options.isfujitsu):
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++03 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -485,9 +485,6 @@ def writeCMakeListsTop(dir):
         print("--->> Writing top level CMakeLists.txt, dir: ",
               dir, file=sys.stderr)
         print("     ", cmakePath, file=sys.stderr)
-
-    runCommand('export CC=/opt/FJSVstclanga/cp-1.0.20.06/bin/fcc')
-    runCommand('export CXX=/opt/FJSVstclanga/cp-1.0.20.06/bin/FCC')
     
     fo = open(cmakePath, 'w')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c++11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -KPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -624,7 +624,7 @@ def writeCMakeListsTop(dir):
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++03 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -I/opt/FJSVstclanga/cp-1.0.20.06/include ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -I/opt/FJSVstclanga/cp-1.0.20.06/include -I/usr/include ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -615,17 +615,14 @@ def writeCMakeListsTop(dir):
     fo.write('\n')
 
     if (options.m32):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
- 
-    if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 -D__linux__ ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n') 
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 -D__linux__ ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++14 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,9 +613,10 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 -lsci_cray ")\n')
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
+        
     if (options.m32):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 ")\n')
 

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,14 +618,14 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
  
     if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=c++03 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++03 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -613,7 +613,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     else:
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -I/opt/FJSVstclanga/cp-1.0.20.06/include ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -618,14 +618,14 @@ def writeCMakeListsTop(dir):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
  
     if (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu17 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 
     if (options.iscray):
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -hstd=c++11 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++03 ")\n')        
+        fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=gnu++17 ")\n')        
     else:
         fo.write('set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -std=c++11 ")\n')
         

--- a/build/cmake/createCMakeLists.py
+++ b/build/cmake/createCMakeLists.py
@@ -617,7 +617,7 @@ def writeCMakeListsTop(dir):
     if (options.m32):
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -m32 ")\n')
     elif (options.isfujitsu):
-        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu99 ")\n')
+        fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -std=gnu11 ")\n')
     else:
         fo.write('set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC ")\n')
 

--- a/codebase/CMakeLists.txt
+++ b/codebase/CMakeLists.txt
@@ -20,8 +20,8 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.10.0")
   cmake_policy(SET CMP0071 NEW)
 endif()
 
-set(CMAKE_C_COMPILER_NAMES clang gcc icc cc)
-set(CMAKE_CXX_COMPILER_NAMES clang++ g++ icpc c++ cxx)
+set(CMAKE_C_COMPILER_NAMES clang fcc gcc icc cc)
+set(CMAKE_CXX_COMPILER_NAMES clang++ FCC CC g++ icpc c++ cxx)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 

--- a/codebase/libs/Ncxx/src/include/Ncxx/NcxxPort.hh
+++ b/codebase/libs/Ncxx/src/include/Ncxx/NcxxPort.hh
@@ -47,6 +47,10 @@
 #include <sys/types.h>
 #endif
 
+#if defined __fujitsu__
+#include <sys/types.h>
+#endif
+
 using namespace std;
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We update the configuration files so that we could compile the samurai package using the Cray and Fujitsu compilers. Two new options `iscray` and `isfujitsu` are added to specify some specific flags for these two new compilers.

We use the GCC version of HDF5 and NetCDF libraries that come with the host machine.