### PR TITLE
Fix a path issue in build_lrose_manual script

### DIFF
--- a/build/scripts/build_lrose_manual.py
+++ b/build/scripts/build_lrose_manual.py
@@ -121,7 +121,7 @@ def main():
     # compute core dir relative to script dir
 
     global coreDir
-    coreDir = os.path.join(thisScriptDir, "..")
+    coreDir = os.path.join(thisScriptDir, "../..")
     os.chdir(coreDir)
     coreDir = os.getcwd()
     


### PR DESCRIPTION
lrose-core/codebase is two directories above the script in lrose-core/build/scripts.