### PR TITLE
Set writing both scan name and scan ID in output from the params file.

### DIFF
--- a/codebase/apps/Radx/src/RadxConvert/RadxConvert.cc
+++ b/codebase/apps/Radx/src/RadxConvert/RadxConvert.cc
@@ -1387,6 +1387,7 @@ void RadxConvert::_setupWrite(RadxFile &file)
   file.setWriteSubsecsInFileName(_params.include_subsecs_in_file_name);
   file.setWriteScanTypeInFileName(_params.include_scan_type_in_file_name);
   file.setWriteScanNameInFileName(_params.include_scan_name_in_file_name);
+  file.setWriteScanIdInFileName(_params.include_scan_id_in_file_name);
   file.setWriteRangeResolutionInFileName(_params.include_range_resolution_in_file_name);
   file.setWriteVolNumInFileName(_params.include_vol_num_in_file_name);
   file.setWriteHyphenInDateTime(_params.use_hyphen_in_file_name_datetime_part);


### PR DESCRIPTION
At some point the scan ID and scan name metadata fields from the leosphere got combined. Scan ID is numeric, and assigns a new number whenever the user modifies a scan pattern. Scan name is fixed/dbs/rhi/ppi, more or less analagous to scan type from RadxConvert.
I have been building lrose from just after the bugfix Brenda did for us earlier this year, since I haven't gotten the master branch to build on the ISS server, but I think this should be able to merge.