### PR TITLE
Leosphere format update

### DIFF
--- a/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
+++ b/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
@@ -1347,10 +1347,10 @@ void LeoCf2RadxFile::_setAnglesFromXml(const string &xml)
   _elLimit1 = NAN;
   _elLimit2 = NAN;
 
-  RadxXml::readDouble(xml, "Azimuth_Angle_1_(�)", _azLimit1);
-  RadxXml::readDouble(xml, "Azimuth_Angle_2_(�)", _azLimit2);
-  RadxXml::readDouble(xml, "Elevation_Angle_1_(�)", _elLimit1);
-  RadxXml::readDouble(xml, "Elevation_Angle_2_(�)", _elLimit2);
+  RadxXml::readDouble(xml, "Azimuth_Angle_1_(º)", _azLimit1);
+  RadxXml::readDouble(xml, "Azimuth_Angle_2_(º)", _azLimit2);
+  RadxXml::readDouble(xml, "Elevation_Angle_1_(º)", _elLimit1);
+  RadxXml::readDouble(xml, "Elevation_Angle_2_(º)", _elLimit2);
 
   _fixedAngle = -9999;
   _rhiMode = false;

--- a/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
+++ b/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
@@ -1347,10 +1347,10 @@ void LeoCf2RadxFile::_setAnglesFromXml(const string &xml)
   _elLimit1 = NAN;
   _elLimit2 = NAN;
 
-  RadxXml::readDouble(xml, "Azimuth_Angle_1_(°)", _azLimit1);
-  RadxXml::readDouble(xml, "Azimuth_Angle_2_(°)", _azLimit2);
-  RadxXml::readDouble(xml, "Elevation_Angle_1_(°)", _elLimit1);
-  RadxXml::readDouble(xml, "Elevation_Angle_2_(°)", _elLimit2);
+  RadxXml::readDouble(xml, "Azimuth_Angle_1_(ï¿½)", _azLimit1);
+  RadxXml::readDouble(xml, "Azimuth_Angle_2_(ï¿½)", _azLimit2);
+  RadxXml::readDouble(xml, "Elevation_Angle_1_(ï¿½)", _elLimit1);
+  RadxXml::readDouble(xml, "Elevation_Angle_2_(ï¿½)", _elLimit2);
 
   _fixedAngle = -9999;
   _rhiMode = false;
@@ -2419,7 +2419,16 @@ void LeoCf2RadxFile::_readSweepsMetaAsInFile()
      }
      string name = att.getName();
      string value;
-     att.getValues(value);
+     try{
+        att.getValues(value);
+     } catch (NcxxException &e) {
+        // newer leosphere netcdfs have res_id as an int attribute rather than
+        // a string (it's an int number either way). convert here to avoid
+        // exception about getting a string value out of an int attribute.
+        int intValue;
+        att.getValues(&intValue);
+        value = to_string(intValue);
+     }
      //if (name.find("scan_file_name") != string::npos) {
        //if (value.find("RHI") != string::npos)
        //  _sweepMode = value; //(Radx::SWEEP_MODE_RHI);  

--- a/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
+++ b/codebase/libs/Radx/src/Leosphere/LeoCf2RadxFile.cc
@@ -1347,10 +1347,10 @@ void LeoCf2RadxFile::_setAnglesFromXml(const string &xml)
   _elLimit1 = NAN;
   _elLimit2 = NAN;
 
-  RadxXml::readDouble(xml, "Azimuth_Angle_1_(º)", _azLimit1);
-  RadxXml::readDouble(xml, "Azimuth_Angle_2_(º)", _azLimit2);
-  RadxXml::readDouble(xml, "Elevation_Angle_1_(º)", _elLimit1);
-  RadxXml::readDouble(xml, "Elevation_Angle_2_(º)", _elLimit2);
+  RadxXml::readDouble(xml, "Azimuth_Angle_1_(°)", _azLimit1);
+  RadxXml::readDouble(xml, "Azimuth_Angle_2_(°)", _azLimit2);
+  RadxXml::readDouble(xml, "Elevation_Angle_1_(°)", _elLimit1);
+  RadxXml::readDouble(xml, "Elevation_Angle_2_(°)", _elLimit2);
 
   _fixedAngle = -9999;
   _rhiMode = false;

--- a/codebase/libs/Radx/src/Radx/RadxVol.cc
+++ b/codebase/libs/Radx/src/Radx/RadxVol.cc
@@ -2657,12 +2657,12 @@ void RadxVol::combineRhi()
 
   // ensure there is only one sweep in the volume
   if (_sweeps.size() != 1) {
-    cerr << "Error: combineRHI only one sweep per volume" << endl;
+    cerr << "Error: combineRHI requires only one sweep per volume" << endl;
     return;
   }
 
   if (!checkIsRhi()) {
-    cerr << "Error: attempting to combine RHI scans on non-RHI data" << endl;
+    cerr << "Warning: attempting to combine RHI scans on non-RHI data" << endl;
     return;
   }
   


### PR DESCRIPTION
The ISS Leosphere lidar got a software update recently that slightly changed the format of its netCDF (supposedly CFRadial but not quite) files. The specific difference that matters to RadxConvert is that the type of the res_id attribute in the sweep group has changed. 
In earlier files:
`:res_id = "3" ;` (string attribute)
But now it's:
`:res_id = 7 ;` (int attribute)
RadxConvert was failing because it was attempting to access res_id as a string attribute when it wasn't. I added catching that netcdf exception and instead trying to read the attribute as an int, then converting to string, and now RadxConvert successfully generates CFRadial files.