### PR TITLE
Update cmake build script to work on alma9

### DIFF
--- a/build/scripts/build_lrose_cmake.py
+++ b/build/scripts/build_lrose_cmake.py
@@ -183,11 +183,11 @@ def main():
         os.makedirs(cmakeBuildDir)
     except:
         print("Dir exists: " + cmakeBuildDir, file=sys.stderr)
-    os.chdir(cmakeBuildDir)
     if (options.use_cmake3):
+        os.chdir(cmakeBuildDir)
         shellCmd("cmake3 -DCMAKE_INSTALL_PREFIX=" + options.prefix + " ..")
     else:
-        shellCmd("cmake -DCMAKE_INSTALL_PREFIX=" + options.prefix + " ..")
+        shellCmd("cmake -S . -B build")
 
     # build and install libs
 


### PR DESCRIPTION
I updated the build_lrose_cmake.py script based on the build instructions Chris gave me in #133, and it now successfully builds lrose on alma9. I haven't tested it on any other build systems.

Feel free to use if it's helpful or ignore if it isn't.