### PR TITLE
Fix Sigmet2Dsr build

### DIFF
--- a/codebase/apps/ingest/src/Sigmet2Dsr/Makefile
+++ b/codebase/apps/ingest/src/Sigmet2Dsr/Makefile
@@ -40,7 +40,7 @@ LOC_LDFLAGS =
 LOC_LIBS = \
 	-lFmq -ltrmm_rsl $(LEX_LIB) -ldsserver \
 	-ldidss -lrapformats -ltoolsa -lpthread -ldataport \
-	-ltdrp -lbz2 -lz
+	-ltdrp -lbz2 -lz -lphysics -leuclid -lrapmath
 
 HDRS = \
 	$(PARAMS_HH) \


### PR DESCRIPTION
Fix Sigmet2Dsr link stage. Sigmet2Dsr is not wired to the repository build infrastructure so did not impact releases.

Tested with `make`:

```
~/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr$ make clean strip install
/bin/rm -f core a.out
/bin/rm -f *.i *.o  *.ln *~ *.mod
strip Sigmet2Dsr
make _CC="gcc" _CPPC="g++" _FC="gfortran" _F90C="gfortran" \
_F95C="gfortran" \
DBUG_OPT_FLAGS="-O2" target
make[1]: Entering directory '/home/ubuntu/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr'
echo Making C++ program ... ; \
make _CC="gcc" _CPPC="g++" _FC="gfortran" DBUG_OPT_FLAGS="-O2" DEBUG_CFLAGS="" DEBUG_LIBS="" DEBUG_LDFLAGS="" SYS_LIBS="" SYS_CFLAGS=" -DLINUX_LROSE -D_BSD_TYPES -DF_UNDERSCORE2  -fPIC" Sigmet2Dsr;
Making C++ program ...
make[2]: Entering directory '/home/ubuntu/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr'
g++   -DLINUX_LROSE -D_BSD_TYPES -DF_UNDERSCORE2  -fPIC  -std=c++17 -fPIC -O2 -c  -I/opt/lrose/include   Params.cc
g++   -DLINUX_LROSE -D_BSD_TYPES -DF_UNDERSCORE2  -fPIC  -std=c++17 -fPIC -O2 -c  -I/opt/lrose/include   Main.cc
g++   -DLINUX_LROSE -D_BSD_TYPES -DF_UNDERSCORE2  -fPIC  -std=c++17 -fPIC -O2 -c  -I/opt/lrose/include   Args.cc
g++   -DLINUX_LROSE -D_BSD_TYPES -DF_UNDERSCORE2  -fPIC  -std=c++17 -fPIC -O2 -c  -I/opt/lrose/include   Sigmet2Dsr.cc
echo Linking C++ program ...
Linking C++ program ...
LD_LIBRARY_PATH=::
/bin/rm -f Sigmet2Dsr
g++ -O2 -o Sigmet2Dsr \
                Params.o Main.o Args.o Sigmet2Dsr.o    -L/opt/lrose/lib  -L/usr/lib64  "-Wl,-rpath,/opt/lrose/lib" -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lFmq -ltrmm_rsl -ll -ldsserver -ldidss -lrapformats -ltoolsa -lpthread -ldataport -ltdrp -lbz2 -lz -lphysics -leuclid -lrapmath
make[2]: Leaving directory '/home/ubuntu/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr'
make[1]: Leaving directory '/home/ubuntu/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr'
if /usr/bin/test -d /opt/lrose/bin; then :; else \
        /bin/mkdir -p /opt/lrose/bin; fi ; \
if /usr/bin/test -f /opt/lrose/bin/Sigmet2Dsr ;\
then \
        /bin/mv -f /opt/lrose/bin/Sigmet2Dsr /opt/lrose/bin/Sigmet2Dsr.bak ;\
        /bin/cp Sigmet2Dsr /opt/lrose/bin/Sigmet2Dsr ;\
        /bin/rm -f /opt/lrose/bin/Sigmet2Dsr.bak ;\
else \
        /bin/cp Sigmet2Dsr /opt/lrose/bin/Sigmet2Dsr ; \
fi
if /usr/bin/test "" = "" ; then :; else \
        echo "Sigmet2Dsr -- source: `pwd`" >> /opt/lrose/bin/README.src_dir_info ;\
fi
````

On current and up to date Ubuntu LTS:
```
~/git/lrose-core/codebase/apps/ingest/src/Sigmet2Dsr$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.3 LTS"
```